### PR TITLE
fix: add missing `th:` prefix for meta description tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -85,7 +85,7 @@ const themeSettingScript = `<script type="application/json" id="theme-config" th
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width" />
     <meta name="author" th:content="${theme.config?.sidebar?.profile?.name}" />
-    <meta name="description" content={description} />
+    <meta name="description" th:content={description} />
     <meta property="og:site_name" th:content="${site.title}" />
     <meta property="og:title" th:content={title} />
     <meta

--- a/src/pages/page.astro
+++ b/src/pages/page.astro
@@ -4,6 +4,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 
 <MainGridLayout
   title="${singlePage.spec.title + ' - ' + site.title}"
+  description="${singlePage.spec.excerpt.raw ?: site.subtitle}"
   setOGTypeArticle={true}
   showToc={true}
 >


### PR DESCRIPTION
#fix: add missing `th:` prefix for meta description tag

---

## 问题

首页的 `<meta name="description">` 渲染为字面文本 `${theme.config?.sidebar?.profile?.bio}` 而非实际值，因为 `Layout.astro` 第 88 行漏了 `th:` 前缀：

```diff
- <meta name="description" content={description} />
+ <meta name="description" th:content={description} />
```

`content={description}` 由 Astro 编译时求值，`${...}` 表达式未传给 Thymeleaf 处理。加 `th:` 后，Thymeleaf 运行时正确解析。

## 影响页面

| 页面 | description 数据源 |
|------|-------------------|
| index | `theme.config?.sidebar?.profile?.bio` |
| post | `post.status.excerpt` |
| photos | `title + ' - ' + site.title` |
| moments | `title + ' - ' + site.title` |

## 附加修复：单页面（page.astro）

单页面模板未传入 `description` prop，导致 `<meta name="description" content="">`。新增一行取 `singlePage.spec.excerpt.raw`，无 excerpt 时回退到 `site.subtitle`。

## 改动文件

- `src/layouts/Layout.astro` — `content={description}` → `th:content={description}`
- `src/pages/page.astro` — 新增 `description` prop

## SEO 影响

修复前，一次 Bing Webmaster 站点扫描中发现 **多个页面缺少有效的 meta description**：

| 严重度 | 数量 | 问题 | 根因 |
|--------|------|------|------|
| 🔴 错误 | 1 | 首页 meta description 显示为 `${...}` 字面文本 | `content` 漏 `th:` |
| 🔴 错误 | 1 | 文章页完全无 `<meta name="description">` | 同上，表达式未求值 |
| 🔴 错误 | 3 | 单页面（关于/隐私/用户协议）meta description 为空 | `page.astro` 未传 description |
| 🟡 次要 | 13 | 归档/分类/标签等列表页 meta description 为空 | 这些页面未传 description，默认 `""` |

此 PR 修复了这些错误。
合并后，已发布文章的 excerpt 会自动作为 meta description 输出，单页面回退到站点副标题，首页从 sidebar bio 取值。所有值均由 Thymeleaf 在服务端正确求值，不再输出字面模板表达式。