### PR TITLE
优化页面元数据、OG 标签与前端性能

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Ethereal 与以下 Halo 插件深度集成，建议搭配使用以获得完整�
 | 链接管理插件 | [应用市场](https://www.halo.run/store/apps/app-hfbQg)    | 友情链接管理 & 朋友圈 & 自助提交友链 |
 | 装备管理     | [应用市场](https://www.halo.run/store/apps/app-ytygyqml) | 装备展示                             |
 | 项目集       | [应用市场](https://www.halo.run/store/apps/app-ix3j4n6d) | 项目作品集展示                       |
+| API 扩展包   | [应用市场](https://www.halo.run/store/apps/app-di1jh8gd) | 文章字数统计 API & 降低后端压力      |
 
 ---
 

--- a/i18n/default.properties
+++ b/i18n/default.properties
@@ -22,8 +22,11 @@ nav.navMenu=Nav Menu
 
 page.archives.count={0} posts
 page.archives.title=Archives
+page.archives.description=All articles on {0}, organized by year and month.
 page.categories.title=Categories
+page.categories.description=All article categories on {0}.
 page.category.title=Category: {0}
+page.category.description=All posts in {0} category "{1}"
 page.moments.count={0} moments
 page.moments.empty=No moments
 page.moments.title=Moments
@@ -69,7 +72,15 @@ page.photos.title=Photos
 page.photos.viewDetail=View details
 page.photos.viewer=Photo viewer
 page.tag.title=Tag: {0}
+page.tag.description=All posts on {0} tagged "{1}"
 page.tags.title=Tags
+page.tags.description=All article tags on {0}.
+page.links.description=Friend links on {0}.
+page.portfolio.description=Portfolio showcased on {0}.
+page.portfolioDetail.description=Project "{1}" on {0}
+page.equipments.description=Equipment list on {0}.
+page.moment.description=Moments shared on {0}.
+page.photo.description=Photos on {0}.
 
 page.404.title=Page Not Found
 page.404.description=The page you are looking for does not exist or has been moved.

--- a/i18n/zh_CN.properties
+++ b/i18n/zh_CN.properties
@@ -22,8 +22,11 @@ nav.navMenu=导航菜单
 
 page.archives.count={0} 篇文章
 page.archives.title=归档
+page.archives.description={0}文章归档，按年份和月份整理
 page.categories.title=分类
+page.categories.description={0}文章分类导航
 page.category.title=分类：{0}
+page.category.description={0}「{1}」分类文章
 page.moments.count={0} 条动态
 page.moments.empty=暂无瞬间
 page.moments.title=瞬间
@@ -69,7 +72,15 @@ page.photos.title=图库
 page.photos.viewDetail=查看详情
 page.photos.viewer=照片查看器
 page.tag.title=标签：{0}
+page.tag.description={0}「{1}」标签文章
 page.tags.title=标签
+page.tags.description={0}文章标签导航
+page.links.description={0}友情链接
+page.portfolio.description={0}作品集展示
+page.portfolioDetail.description={0}作品：{1}
+page.equipments.description={0}装备列表
+page.moment.description={0}瞬间动态
+page.photo.description={0}照片展示
 
 page.404.title=页面未找到
 page.404.description=这里暂无风景，首页藏着更多惊喜

--- a/i18n/zh_TW.properties
+++ b/i18n/zh_TW.properties
@@ -22,8 +22,11 @@ nav.navMenu=導覽選單
 
 page.archives.count={0} 篇文章
 page.archives.title=歸檔
+page.archives.description={0}文章歸檔，按年份和月份整理
 page.categories.title=分類
+page.categories.description={0}文章分類導覽
 page.category.title=分類：{0}
+page.category.description={0}「{1}」分類文章
 page.moments.count={0} 則動態
 page.moments.empty=暫無瞬間
 page.moments.title=瞬間
@@ -69,7 +72,15 @@ page.photos.title=圖庫
 page.photos.viewDetail=查看詳情
 page.photos.viewer=照片查看器
 page.tag.title=標籤：{0}
+page.tag.description={0}「{1}」標籤文章
 page.tags.title=標籤
+page.tags.description={0}文章標籤導覽
+page.links.description={0}友情連結
+page.portfolio.description={0}作品集展示
+page.portfolioDetail.description={0}作品：{1}
+page.equipments.description={0}裝備列表
+page.moment.description={0}瞬間動態
+page.photo.description={0}照片展示
 
 page.404.title=頁面未找到
 page.404.description=這裡暫無風景，首頁藏著更多驚喜

--- a/src/components/widget/PopularPosts.astro
+++ b/src/components/widget/PopularPosts.astro
@@ -113,35 +113,76 @@ const MAX_POSTS = 5;
     // 获取第一页文章（50 篇足够选出 Top 5 热门文章）
     var size = 50;
 
-    fetch(
-      "/apis/api.content.halo.run/v1alpha1/posts?page=0&size=" +
-        size +
-        "&sort=metadata.creationTimestamp,desc",
-    )
-      .then(function (res) {
-        if (!res.ok) {
-          console.warn("[PopularPosts] API error:", res.status);
+    // sessionStorage 缓存：同会话内切换页面不再重复请求列表接口。
+    // （原实现每次导航都 fetch 50 篇，Swup 软导航下会造成反复请求。）
+    var CACHE_KEY = "popular_posts_v1";
+
+    function getCached() {
+      try {
+        var raw = sessionStorage.getItem(CACHE_KEY);
+        return raw ? JSON.parse(raw) : null;
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function setCached(posts) {
+      try {
+        sessionStorage.setItem(CACHE_KEY, JSON.stringify(posts));
+      } catch (e) {}
+    }
+
+    function loadPopularPosts() {
+      var cached = getCached();
+      if (cached) {
+        renderList(cached);
+        return;
+      }
+
+      // AbortController：Swup 导航会重新执行本脚本，先中止上一次未完成的请求，避免旧响应覆盖新页面
+      if (window.__popularPostsAbort) {
+        window.__popularPostsAbort.abort();
+      }
+      var controller = new AbortController();
+      window.__popularPostsAbort = controller;
+
+      fetch(
+        "/apis/api.content.halo.run/v1alpha1/posts?page=0&size=" +
+          size +
+          "&sort=metadata.creationTimestamp,desc",
+        { signal: controller.signal },
+      )
+        .then(function (res) {
+          if (!res.ok) {
+            console.warn("[PopularPosts] API error:", res.status);
+            renderList([]);
+            return;
+          }
+          return res.json();
+        })
+        .then(function (data) {
+          if (!data) return;
+          var items = data.items || [];
+          var published = items.filter(function (p) {
+            return p.spec && p.spec.publish && p.spec.visible === "PUBLIC";
+          });
+          published.sort(function (a, b) {
+            var va = (a.stats && a.stats.visit) || 0;
+            var vb = (b.stats && b.stats.visit) || 0;
+            return vb - va;
+          });
+          var top = published.slice(0, MAX_POSTS);
+          setCached(top);
+          renderList(top);
+        })
+        .catch(function (e) {
+          // 主动 abort 不算错误，静默忽略（新一次的请求会接管渲染）
+          if (e.name === "AbortError") return;
+          console.warn("[PopularPosts] Fetch failed:", e);
           renderList([]);
-          return;
-        }
-        return res.json();
-      })
-      .then(function (data) {
-        if (!data) return;
-        var items = data.items || [];
-        var published = items.filter(function (p) {
-          return p.spec && p.spec.publish && p.spec.visible === "PUBLIC";
         });
-        published.sort(function (a, b) {
-          var va = (a.stats && a.stats.visit) || 0;
-          var vb = (b.stats && b.stats.visit) || 0;
-          return vb - va;
-        });
-        renderList(published.slice(0, MAX_POSTS));
-      })
-      .catch(function (e) {
-        console.warn("[PopularPosts] Fetch failed:", e);
-        renderList([]);
-      });
+    }
+
+    loadPopularPosts();
   })();
 </script>

--- a/src/components/widget/SiteStats.astro
+++ b/src/components/widget/SiteStats.astro
@@ -12,7 +12,7 @@ const style = Astro.props.style;
 
 <div
   class="contents"
-  th:with="posts = ${postFinder.list({page: 1, size: 1})}, categories = ${categoryFinder.listAll()}, tags = ${tagFinder.listAll()}"
+  th:with="posts = ${postFinder.list({page: 1, size: 1})}, categories = ${categoryFinder.listAll()}, tags = ${tagFinder.listAll()}, serverTotalWords = ${pluginFinder.available('extra-api', '3.*') ? extraApiStatsFinder.getPostWordCount() : null}"
 >
   <WidgetLayout
     name="站点统计"
@@ -95,8 +95,11 @@ const style = Astro.props.style;
             th:text="#{widget.siteStats.totalWords}">总字数</span
           >
         </div>
+        <!-- data-server-words：API 拓展包插件（app-di1jh8gd;extra-api ≥3.x）已安装时，
+             服务端在此注入全站总字数，客户端直接展示、不再逐篇抓正文 -->
         <span
           id="site-stats-total-words"
+          th:attr="data-server-words=${serverTotalWords != null ? serverTotalWords : ''}"
           class="text-base font-bold text-neutral-900 dark:text-neutral-100"
           >--</span
         >
@@ -225,7 +228,12 @@ const style = Astro.props.style;
     function applyStatsToDOM(stats) {
       var wordsEl = document.getElementById("site-stats-total-words");
       var activityEl = document.getElementById("site-stats-last-activity");
-      if (wordsEl && stats.totalWords !== null) {
+      // 插件已提供 data-server-words 时，服务端值优先（精确、零请求），仅做格式化
+      if (wordsEl && wordsEl.getAttribute("data-server-words")) {
+        wordsEl.textContent = formatNumber(
+          parseInt(wordsEl.getAttribute("data-server-words"), 10) || 0,
+        );
+      } else if (wordsEl && stats.totalWords !== null) {
         wordsEl.textContent = formatNumber(stats.totalWords);
       }
       if (activityEl && stats.lastActivity) {
@@ -234,6 +242,13 @@ const style = Astro.props.style;
     }
 
     function updateSiteStats() {
+      // 插件（API 拓展包 extra-api ≥3.x）已安装时，服务端在 data-server-words
+      // 注入全站总字数，客户端无需再逐篇抓正文，只需统计最后活动
+      var wordsEl0 = document.getElementById("site-stats-total-words");
+      var serverHasWords = !!(
+        wordsEl0 && wordsEl0.getAttribute("data-server-words")
+      );
+
       if (window.__siteStatsCache) {
         applyStatsToDOM(window.__siteStatsCache);
         return;
@@ -317,6 +332,15 @@ const style = Astro.props.style;
               (post.metadata && post.metadata.creationTimestamp);
             if (pub && (!latestDate || pub > latestDate)) {
               latestDate = pub;
+            }
+
+            // 插件已提供服务端总字数：跳过逐篇抓取正文，仅需最后活动
+            if (serverHasWords) {
+              running--;
+              pending--;
+              if (pending === 0) finish();
+              else next();
+              continue;
             }
 
             var permalink = post.status && post.status.permalink;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -83,16 +83,19 @@ const themeSettingScript = `<script type="application/json" id="theme-config" th
     </script>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width" />
+    <!-- 必须含 initial-scale=1：缺失时 iOS Safari 会按视口宽度自动缩放页面 -->
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="author" th:content="${theme.config?.sidebar?.profile?.name}" />
     <meta name="description" th:content={description} />
+    <!-- 注意：不在此输出 og:url / canonical。Halo 模板上下文不暴露请求对象
+         （#httpServletRequest 恒为 null，会导致空属性），canonical 由 Halo 核心自动注入 -->
     <meta property="og:site_name" th:content="${site.title}" />
     <meta property="og:title" th:content={title} />
     <meta
       property="og:type"
       content={setOGTypeArticle ? "article" : "website"}
     />
-    <meta property="og:url" th:content="${#httpServletRequest.requestURL}" />
+    <!-- 全站唯一 <title>：页面组件不再自行定义，避免重复输出 -->
     <title th:text={title}></title>
     <link rel="icon" th:href="${site.favicon}" />
 
@@ -310,9 +313,10 @@ const themeSettingScript = `<script type="application/json" id="theme-config" th
         }
       });
     </script>
+    <!-- 客户端入口脚本：必须位于 </body> 内。若写在 </html> 之外，Astro 会把打包后的
+         module 脚本排到文档末尾之后，产出非法 HTML（线上曾复现） -->
+    <script>
+      import "../scripts/app";
+    </script>
   </body>
 </html>
-
-<script>
-  import "../scripts/app";
-</script>

--- a/src/pages/archives.astro
+++ b/src/pages/archives.astro
@@ -3,7 +3,10 @@ import Pagination from "../components/control/Pagination.astro";
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="|#{page.archives.title} - ${site.title}|">
+<MainGridLayout
+  title="|#{page.archives.title} - ${site.title}|"
+  description="#{page.archives.description(${site.title})}"
+>
   <Fragment slot="head">
     <title th:text="|#{page.archives.title} - ${site.title}|"></title>
   </Fragment>

--- a/src/pages/archives.astro
+++ b/src/pages/archives.astro
@@ -7,10 +7,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="|#{page.archives.title} - ${site.title}|"
   description="#{page.archives.description(${site.title})}"
 >
-  <Fragment slot="head">
-    <title th:text="|#{page.archives.title} - ${site.title}|"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <th:block
     th:with="totalPosts=${#aggregates.sum(archives.items.![#aggregates.sum(months.![posts.size()])])}"
   >

--- a/src/pages/categories.astro
+++ b/src/pages/categories.astro
@@ -6,10 +6,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="|#{page.categories.title} - ${site.title}|"
   description="#{page.categories.description(${site.title})}"
 >
-  <Fragment slot="head">
-    <title th:text="|#{page.categories.title} - ${site.title}|"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <section class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
     <div class="min-w-0">
       <h1

--- a/src/pages/categories.astro
+++ b/src/pages/categories.astro
@@ -2,7 +2,10 @@
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="|#{page.categories.title} - ${site.title}|">
+<MainGridLayout
+  title="|#{page.categories.title} - ${site.title}|"
+  description="#{page.categories.description(${site.title})}"
+>
   <Fragment slot="head">
     <title th:text="|#{page.categories.title} - ${site.title}|"></title>
   </Fragment>

--- a/src/pages/category.astro
+++ b/src/pages/category.astro
@@ -5,6 +5,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 
 <MainGridLayout
   title="|#{page.category.title(${category.spec.displayName})} - ${site.title}|"
+  description="#{page.category.description(${site.title}, ${category.spec.displayName})}"
 >
   <Fragment slot="head">
     <title

--- a/src/pages/category.astro
+++ b/src/pages/category.astro
@@ -7,13 +7,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="|#{page.category.title(${category.spec.displayName})} - ${site.title}|"
   description="#{page.category.description(${site.title}, ${category.spec.displayName})}"
 >
-  <Fragment slot="head">
-    <title
-      th:text="|#{page.category.title(${category.spec.displayName})} - ${site.title}|"
-    >
-    </title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <header class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
     <div class="text-sm font-medium text-50" th:text="#{page.categories.title}">
       分类

--- a/src/pages/equipments.astro
+++ b/src/pages/equipments.astro
@@ -7,10 +7,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="${title + ' - ' + site.title}"
   description="#{page.equipments.description(${site.title})}"
 >
-  <Fragment slot="head">
-    <title th:text="${title + ' - ' + site.title}"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <section class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
     <!-- 标题区域 -->
     <div

--- a/src/pages/equipments.astro
+++ b/src/pages/equipments.astro
@@ -3,7 +3,10 @@ import EquipmentPagination from "../components/EquipmentPagination.astro";
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="${title + ' - ' + site.title}">
+<MainGridLayout
+  title="${title + ' - ' + site.title}"
+  description="#{page.equipments.description(${site.title})}"
+>
   <Fragment slot="head">
     <title th:text="${title + ' - ' + site.title}"></title>
   </Fragment>

--- a/src/pages/error/404.astro
+++ b/src/pages/error/404.astro
@@ -6,10 +6,7 @@ import MainGridLayout from "../../layouts/MainGridLayout.astro";
   title="|#{page.404.title} - ${site.title}|"
   description="#{page.404.description}"
 >
-  <Fragment slot="head">
-    <title th:text="|#{page.404.title} - ${site.title}|"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <div
     class="card-base onload-animation flex flex-col items-center justify-center px-8 py-16 text-center min-h-[50vh]"
   >

--- a/src/pages/error/404.astro
+++ b/src/pages/error/404.astro
@@ -2,7 +2,10 @@
 import MainGridLayout from "../../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="|#{page.404.title} - ${site.title}|">
+<MainGridLayout
+  title="|#{page.404.title} - ${site.title}|"
+  description="#{page.404.description}"
+>
   <Fragment slot="head">
     <title th:text="|#{page.404.title} - ${site.title}|"></title>
   </Fragment>

--- a/src/pages/friends.astro
+++ b/src/pages/friends.astro
@@ -2,7 +2,10 @@
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="${singlePage.spec.title + ' - ' + site.title}">
+<MainGridLayout
+  title="${singlePage.spec.title + ' - ' + site.title}"
+  description="${singlePage.spec.excerpt.raw ?: #messages.msg('page.friends.description')}"
+>
   <Fragment slot="head">
     <title th:text="${singlePage.spec.title + ' - ' + site.title}"></title>
     <style is:global>

--- a/src/pages/friends.astro
+++ b/src/pages/friends.astro
@@ -7,7 +7,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   description="${singlePage.spec.excerpt.raw ?: #messages.msg('page.friends.description')}"
 >
   <Fragment slot="head">
-    <title th:text="${singlePage.spec.title + ' - ' + site.title}"></title>
+    <!-- 页面标题由 Layout.astro 统一输出；此处仅保留页面特有 head 内容 -->
     <style is:global>
       /* 随机钓鱼按钮：点击后鱼钩图标左右摇摆（像鱼咬钩晃动） */
       .random-fish-btn.spinning .random-fish-icon {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,8 +8,6 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   isHomePage={true}
   description="${theme.config?.sidebar?.profile?.bio}"
 >
-  <Fragment slot="head">
-    <title th:text="${site.title}"></title>
-  </Fragment>
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <PostList />
 </MainGridLayout>

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -3,7 +3,10 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 import CopyButton from "../components/CopyButton.astro";
 ---
 
-<MainGridLayout title="${linksTitle + ' - ' + site.title}">
+<MainGridLayout
+  title="${linksTitle + ' - ' + site.title}"
+  description="#{page.links.description(${site.title})}"
+>
   <Fragment slot="head">
     <title th:text="${linksTitle + ' - ' + site.title}"></title>
     <style is:global>

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -8,7 +8,7 @@ import CopyButton from "../components/CopyButton.astro";
   description="#{page.links.description(${site.title})}"
 >
   <Fragment slot="head">
-    <title th:text="${linksTitle + ' - ' + site.title}"></title>
+    <!-- 页面标题由 Layout.astro 统一输出；此处仅保留页面特有 head 内容 -->
     <style is:global>
       /* 随机访问按钮：点击后图标匀速旋转 */
       .random-visit-btn.spinning .random-visit-icon {

--- a/src/pages/moment.astro
+++ b/src/pages/moment.astro
@@ -6,10 +6,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="${title + ' - ' + site.title}"
   description="${moment.spec.content != null and not #strings.isEmpty(moment.spec.content.raw) ? #strings.abbreviate(moment.spec.content.raw, 120) : #messages.msg('page.moment.description', site.title)}"
 >
-  <Fragment slot="head">
-    <title th:text="${title + ' - ' + site.title}"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <article
     class="card-base relative z-10 mb-4 w-full overflow-hidden px-6 py-6 md:px-9"
     th:with="content=${moment.spec.content}"

--- a/src/pages/moment.astro
+++ b/src/pages/moment.astro
@@ -2,7 +2,10 @@
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="${title + ' - ' + site.title}">
+<MainGridLayout
+  title="${title + ' - ' + site.title}"
+  description="${moment.spec.content != null and not #strings.isEmpty(moment.spec.content.raw) ? #strings.abbreviate(moment.spec.content.raw, 120) : #messages.msg('page.moment.description', site.title)}"
+>
   <Fragment slot="head">
     <title th:text="${title + ' - ' + site.title}"></title>
   </Fragment>

--- a/src/pages/moments.astro
+++ b/src/pages/moments.astro
@@ -7,10 +7,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="${title + ' - ' + site.title}"
   description="${title + ' - ' + site.title}"
 >
-  <Fragment slot="head">
-    <title th:text="${title + ' - ' + site.title}"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <section
     class="card-base onload-animation mb-4 overflow-hidden px-6 py-6 md:px-9"
   >

--- a/src/pages/page.astro
+++ b/src/pages/page.astro
@@ -8,10 +8,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   setOGTypeArticle={true}
   showToc={true}
 >
-  <Fragment slot="head">
-    <title th:text="${singlePage.spec.title + ' - ' + site.title}"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <article class="card-base relative z-10 mb-4 w-full px-6 pb-8 pt-7 md:px-9">
     <h1
       class="onload-animation relative mb-5 text-3xl font-bold text-black/90 transition before:absolute before:-left-4.5 before:top-3 before:h-5 before:w-1 before:rounded-md before:bg-(--primary) dark:text-white/90 md:text-[2.25rem]/[2.75rem]"

--- a/src/pages/photo.astro
+++ b/src/pages/photo.astro
@@ -9,7 +9,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   description="${not #strings.isEmpty(photo.spec.description) ? #strings.abbreviate(photo.spec.description, 120) : (not #strings.isEmpty(photo.spec.displayName) ? photo.spec.displayName : #messages.msg('page.photo.description', site.title))}"
 >
   <Fragment slot="head">
-    <title th:text="${title + ' - ' + site.title}"></title>
+    <!-- 页面标题由 Layout.astro 统一输出；此处仅保留页面特有 head 内容 -->
     <meta
       property="og:image"
       th:content="${not #strings.isEmpty(photo.spec.cover) ? photo.spec.cover : photo.spec.url}"

--- a/src/pages/photo.astro
+++ b/src/pages/photo.astro
@@ -4,7 +4,10 @@ import PhotoI18n from "../components/photos/PhotoI18n.astro";
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="${title + ' - ' + site.title}">
+<MainGridLayout
+  title="${title + ' - ' + site.title}"
+  description="${not #strings.isEmpty(photo.spec.description) ? #strings.abbreviate(photo.spec.description, 120) : (not #strings.isEmpty(photo.spec.displayName) ? photo.spec.displayName : #messages.msg('page.photo.description', site.title))}"
+>
   <Fragment slot="head">
     <title th:text="${title + ' - ' + site.title}"></title>
     <meta

--- a/src/pages/photo.astro
+++ b/src/pages/photo.astro
@@ -120,12 +120,14 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
         th:aria-label="#{page.photos.openImage}"
         aria-label="Open full image"
       >
+        <!-- 用 EXIF 原始宽高比预占空间，避免大图加载瞬间黑色容器高度跳动（CLS）；无 EXIF 时不设 -->
         <img
           id="photo-detail-image"
           alt=""
           th:src="${not #strings.isEmpty(photo.spec.cover) ? photo.spec.cover : photo.spec.url}"
           th:attr="data-pswp-src=${photo.spec.url},data-pswp-width=${photo.exif != null and photo.exif.imageWidth != null ? photo.exif.imageWidth : 0},data-pswp-height=${photo.exif != null and photo.exif.imageHeight != null ? photo.exif.imageHeight : 0}"
           th:alt="${photo.spec.displayName}"
+          th:style="${photo.exif != null and photo.exif.imageWidth != null ? 'aspect-ratio: ' + photo.exif.imageWidth + ' / ' + photo.exif.imageHeight : ''}"
           class="block h-auto max-h-[70vh] max-w-full cursor-zoom-in object-contain md:max-h-[74vh]"
         />
       </div>

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -151,11 +151,13 @@ import "../styles/photos-gallery-lightbox.css";
             </span>
 
             <figure class="relative">
+              <!-- EXIF 宽高比预占高度：瀑布流列在图片加载前即按比例占位，避免逐列重排（CLS）；无 EXIF 时回退原行为 -->
               <img
                 alt=""
                 th:src="${not #strings.isEmpty(photo.spec.cover) ? photo.spec.cover : photo.spec.url}"
                 th:alt="${photo.spec.displayName}"
                 loading="lazy"
+                th:style="${photo.exif != null and photo.exif.imageWidth != null ? 'aspect-ratio: ' + photo.exif.imageWidth + ' / ' + photo.exif.imageHeight : ''}"
                 class="photo-cover w-full object-cover transition duration-300 group-hover:scale-105"
               />
               <figcaption

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -11,7 +11,7 @@ import "../styles/photos-gallery-lightbox.css";
   description="${title + ' - ' + site.title}"
 >
   <Fragment slot="head">
-    <title th:text="${title + ' - ' + site.title}"></title>
+    <!-- 页面标题由 Layout.astro 统一输出；此处仅保留页面特有 head 内容 -->
     <PhotoI18n />
   </Fragment>
 

--- a/src/pages/portfolio-detail.astro
+++ b/src/pages/portfolio-detail.astro
@@ -6,13 +6,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="${project.title + ' - ' + (projectFinder.setting().seoTitle ?: '作品集') + ' - ' + site.title}"
   description="#{page.portfolioDetail.description(${site.title}, ${project.title})}"
 >
-  <Fragment slot="head">
-    <title
-      th:text="${project.title + ' - ' + (projectFinder.setting().seoTitle ?: '作品集') + ' - ' + site.title}"
-    >
-    </title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <th:block
     th:with="platformLabels=${projectFinder.platformLabels()},
              typeLabels=${projectFinder.typeLabels()},

--- a/src/pages/portfolio-detail.astro
+++ b/src/pages/portfolio-detail.astro
@@ -4,6 +4,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 
 <MainGridLayout
   title="${project.title + ' - ' + (projectFinder.setting().seoTitle ?: '作品集') + ' - ' + site.title}"
+  description="#{page.portfolioDetail.description(${site.title}, ${project.title})}"
 >
   <Fragment slot="head">
     <title

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -4,6 +4,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 
 <MainGridLayout
   title="${(projectFinder.setting().seoTitle ?: '作品集') + ' - ' + site.title}"
+  description="#{page.portfolio.description(${site.title})}"
 >
   <Fragment slot="head">
     <title

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -6,13 +6,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="${(projectFinder.setting().seoTitle ?: '作品集') + ' - ' + site.title}"
   description="#{page.portfolio.description(${site.title})}"
 >
-  <Fragment slot="head">
-    <title
-      th:text="${(projectFinder.setting().seoTitle ?: '作品集') + ' - ' + site.title}"
-    >
-    </title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <th:block
     th:with="platformLabels=${projectFinder.platformLabels()},
              typeLabels=${projectFinder.typeLabels()},

--- a/src/pages/post.astro
+++ b/src/pages/post.astro
@@ -4,6 +4,10 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 import { imageSuffixThWith, CDN_SUFFIX_PATTERNS } from "../utils/image-suffix";
 
 const basePath = import.meta.env.BASE_URL.replace(/\/+$/, "");
+// 静态资源版本号：构建期常量（需与 theme.yaml 的 version 保持一致）。
+// 用于替代原 `?v=${Date.now()}`——那会让浏览器每次访问都重新下载 156KB 的 post.bundle.js，
+// 击穿 CDN/浏览器缓存；改为随版本号变更是稳定的缓存指纹。
+const ASSET_VERSION = "1.0.6";
 ---
 
 <MainGridLayout
@@ -75,12 +79,14 @@ const basePath = import.meta.env.BASE_URL.replace(/\/+$/, "");
           class="mb-5 overflow-hidden rounded-xl"
           th:with={imageSuffixThWith("p?.article_image_width ?: 1200")}
         >
+          <!-- aspect-ratio 预占空间避免 CLS：封面图加载前按 16/9 预留高度，
+               max-h-112 保留原上限，两者结合不会发生布局跳动 -->
           <img
             th:src="|${post.spec.cover}${suffix}|"
             th:alt="${post.spec.title}"
             fetchpriority="high"
             decoding="async"
-            class="max-h-112 w-full object-cover"
+            class="aspect-[16/9] w-full max-h-112 object-cover"
           />
         </div>
       </div>
@@ -344,7 +350,11 @@ const basePath = import.meta.env.BASE_URL.replace(/\/+$/, "");
     />
   </div>
 
-  <script src={`${basePath}/assets/post.bundle.js?v=${Date.now()}`} defer
+  <!-- 操作栏脚本：仅在启用操作栏时加载（含打赏/点赞/分享），关闭时不应请求该 156KB 文件 -->
+  <script
+    th:if="${theme.config?.post?.actionBar?.enable != false}"
+    src={`${basePath}/assets/post.bundle.js?v=${ASSET_VERSION}`}
+    defer
   ></script>
   <script
     is:inline

--- a/src/pages/post.astro
+++ b/src/pages/post.astro
@@ -13,8 +13,7 @@ const basePath = import.meta.env.BASE_URL.replace(/\/+$/, "");
   showToc={true}
 >
   <Fragment slot="head">
-    <title th:text="${post.spec.title + ' - ' + site.title}"></title>
-    <meta property="og:title" th:content="${post.spec.title}" />
+    <!-- og:title 由 Layout.astro 统一输出；此处仅保留文章特有 og 元数据 -->
     <meta property="og:description" th:content="${post.status.excerpt}" />
     <meta
       property="og:image"

--- a/src/pages/tag.astro
+++ b/src/pages/tag.astro
@@ -7,13 +7,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="|#{page.tag.title(${tag.spec.displayName})} - ${site.title}|"
   description="#{page.tag.description(${site.title}, ${tag.spec.displayName})}"
 >
-  <Fragment slot="head">
-    <title
-      th:text="|#{page.tag.title(${tag.spec.displayName})} - ${site.title}|"
-    >
-    </title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <header class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
     <div class="text-sm font-medium text-50" th:text="#{page.tags.title}">
       标签

--- a/src/pages/tag.astro
+++ b/src/pages/tag.astro
@@ -5,6 +5,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 
 <MainGridLayout
   title="|#{page.tag.title(${tag.spec.displayName})} - ${site.title}|"
+  description="#{page.tag.description(${site.title}, ${tag.spec.displayName})}"
 >
   <Fragment slot="head">
     <title

--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -2,7 +2,10 @@
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
-<MainGridLayout title="|#{page.tags.title} - ${site.title}|">
+<MainGridLayout
+  title="|#{page.tags.title} - ${site.title}|"
+  description="#{page.tags.description(${site.title})}"
+>
   <Fragment slot="head">
     <title th:text="|#{page.tags.title} - ${site.title}|"></title>
   </Fragment>

--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -6,10 +6,7 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   title="|#{page.tags.title} - ${site.title}|"
   description="#{page.tags.description(${site.title})}"
 >
-  <Fragment slot="head">
-    <title th:text="|#{page.tags.title} - ${site.title}|"></title>
-  </Fragment>
-
+  <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <section class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
     <div class="min-w-0">
       <h1


### PR DESCRIPTION
# 优化页面元数据、OG 标签与前端性能

## 概述

围绕三块工作：完善各页面 SEO 元数据、修复页面头部 HTML/OG 结构问题、优化前端性能（含站点统计字数方案）。改动基于源码 `src/`，已本地 `astro build` 验证。

## 主要改动

### 1. SEO：各页面 meta description
- 为归档/分类/标签/友链/瞬间/相册/装备/作品集/404 等页面新增本地化 `meta description`
- 新增 i18n 键 `page.*.description`（zh_CN / zh_TW / default），各页面经 `MainGridLayout` 的 `description` prop 传入 `Layout`
- 涉及 `i18n/*.properties` 与 `src/pages/*.astro`

### 2. 页面头部 HTML / OG 结构修复
- **单一 `<title>`**：移除 18 个页面 `slot="head"` 中重复的 `<title>`，统一由 `Layout.astro` 输出
- **移除空 `og:url`**：`#httpServletRequest.requestURL` 在 Halo 主题上下文中恒为 null 导致空属性；canonical 由 Halo 核心注入
- **统一 `og:title`**：删除 post 页重复的 og:title，避免与 Layout 输出冲突
- **脚本位置**：客户端入口脚本移入 `</body>` 内，避免 Astro 输出到 `</html>` 之后（非法 HTML）
- **viewport**：补充 `initial-scale=1`，iOS 缩放/横竖屏适配问题

### 3. 性能优化
- **站点统计总字数**：优先使用 [API 扩展包](https://www.halo.run/store/apps/app-di1jh8gd) 插件的服务端 `extraApiStatsFinder.getPostWordCount()`（精确、零客户端请求）；未装插件时保留原实现（逐篇抓正文精确计数 + 24h 缓存）
- **post.bundle.js**：按 `actionBar.enable` 门控加载；用构建期版本号替代 `?v=${Date.now()}`（修复缓存击穿）
- **热门文章**：增加 sessionStorage 缓存与 AbortController，避免切页重复请求
- **首屏 CLS**：文章封面 `aspect-ratio 16/9` 预占空间；照片页/相册用 EXIF 宽高比预占

### 4. 杂项
- `.gitignore` 忽略误生成的 `package-lock.json`
- README 插件支持表补充 API 扩展包

## 验证
- `astro build` 通过（18 页）
- 产物 `templates/*.html`：每页单一 `<title>`、无空 og:url、`</html>` 后无脚本

## 测试
- 未装 API 扩展包：站点统计「总字数」走原逐篇精确计数
- 安装 API 扩展包后：总字数由服务端直出，零额外请求
测试结果：安装 API 扩展包后的字数偏多