### PR TITLE
修改“瞬间”页面的标签展示逻辑

### DIFF
--- a/src/components/control/TaxonomyHeader.astro
+++ b/src/components/control/TaxonomyHeader.astro
@@ -1,0 +1,37 @@
+---
+// 分类/标签详情页的上下文标题。页面只负责传入当前术语的表达式，
+// 列表内容仍由页面组装，避免把路由级 PostList 隐藏在通用组件中。
+interface Props {
+  labelExpr: string;
+  label: string;
+  titleExpr: string;
+  title: string;
+  descriptionExpr?: string;
+  description?: string;
+}
+
+const {
+  labelExpr,
+  label,
+  titleExpr,
+  title,
+  descriptionExpr,
+  description = "",
+} = Astro.props;
+---
+
+<header class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
+  <div class="text-sm font-medium text-50" th:text={labelExpr}>{label}</div>
+  <h1 class="mt-1 text-3xl font-bold text-90" th:text={titleExpr}>{title}</h1>
+  {
+    descriptionExpr && (
+      <p
+        class="mt-2 text-75"
+        th:if={`\${not #strings.isEmpty(${descriptionExpr.replace(/^\$\{/, "").replace(/\}$/, "")})}`}
+        th:text={descriptionExpr}
+      >
+        {description}
+      </p>
+    )
+  }
+</header>

--- a/src/pages/archives.astro
+++ b/src/pages/archives.astro
@@ -1,5 +1,6 @@
 ---
 import Pagination from "../components/control/Pagination.astro";
+import PageHeader from "../components/control/PageHeader.astro";
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
@@ -14,29 +15,17 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   >
     <div class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
       <!-- 标题区域 -->
-      <div class="min-w-0 mb-6">
-        <h1
-          class="relative mb-2 text-3xl font-bold text-90 before:absolute before:-left-4.5 before:top-3 before:h-5 before:w-1 before:rounded-md before:bg-(--primary) md:text-4xl"
-          th:text="#{page.archives.title}"
-        >
-          归档
-        </h1>
-        <div class="flex flex-wrap items-center gap-1.5 text-sm">
-          <span
-            class="icon-[material-symbols--library-books-outline-rounded] text-base text-(--primary)"
-          ></span>
-          <span
-            class="font-bold text-(--primary)"
-            th:text="#{page.archives.subtitle}">文章归档</span
-          >
-          <span class="text-30">·</span>
-          <span
-            class="text-50"
-            th:text="#{page.archives.subtitleCount(${totalPosts})}"
-            >共 0 篇文章</span
-          >
-        </div>
-      </div>
+      <PageHeader
+        containerClass="mb-6"
+        titleExpr="#{page.archives.title}"
+        title="归档"
+        iconClass="icon-[material-symbols--library-books-outline-rounded]"
+        labelExpr="#{page.archives.subtitle}"
+        label="文章归档"
+        sepShowIfExpr="${true}"
+        subExpr="#{page.archives.subtitleCount(${totalPosts})}"
+        sub="共 0 篇文章"
+      />
 
       <div
         class="contents"

--- a/src/pages/categories.astro
+++ b/src/pages/categories.astro
@@ -1,5 +1,6 @@
 ---
 import MainGridLayout from "../layouts/MainGridLayout.astro";
+import PageHeader from "../components/control/PageHeader.astro";
 ---
 
 <MainGridLayout
@@ -8,29 +9,18 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 >
   <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <section class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
-    <div class="min-w-0">
-      <h1
-        class="relative mb-2 text-3xl font-bold text-90 before:absolute before:-left-4.5 before:top-3 before:h-5 before:w-1 before:rounded-md before:bg-(--primary) md:text-4xl"
-        th:text="#{page.categories.title}"
-      >
-        分类
-      </h1>
-      <div class="mb-6 flex flex-wrap items-center gap-1.5 text-sm">
-        <span
-          class="icon-[material-symbols--folder-open-rounded] text-base text-(--primary)"
-        ></span>
-        <span
-          class="font-bold text-(--primary)"
-          th:text="#{page.categories.subtitle}">文章分类</span
-        >
-        <span class="text-30">·</span>
-        <span
-          th:if="${categories != null}"
-          th:text="#{page.categories.subtitleCount(${#lists.size(categories)})}"
-          class="text-50">0 个分类</span
-        >
-      </div>
-    </div>
+    <PageHeader
+      containerClass="mb-6"
+      titleExpr="#{page.categories.title}"
+      title="分类"
+      iconClass="icon-[material-symbols--folder-open-rounded]"
+      labelExpr="#{page.categories.subtitle}"
+      label="文章分类"
+      sepShowIfExpr="${true}"
+      subExpr="#{page.categories.subtitleCount(${#lists.size(categories)})}"
+      sub="0 个分类"
+      subShowIfExpr="${categories != null}"
+    />
     <div class="grid gap-3 sm:grid-cols-2">
       <a
         th:each="category, stat : ${categories}"

--- a/src/pages/category.astro
+++ b/src/pages/category.astro
@@ -1,5 +1,6 @@
 ---
 import PostList from "../components/PostList.astro";
+import TaxonomyHeader from "../components/control/TaxonomyHeader.astro";
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
@@ -8,22 +9,12 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   description="#{page.category.description(${site.title}, ${category.spec.displayName})}"
 >
   <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
-  <header class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
-    <div class="text-sm font-medium text-50" th:text="#{page.categories.title}">
-      分类
-    </div>
-    <h1
-      class="mt-1 text-3xl font-bold text-90"
-      th:text="${category.spec.displayName}"
-    >
-      Category
-    </h1>
-    <p
-      class="mt-2 text-75"
-      th:if="${not #strings.isEmpty(category.spec.description)}"
-      th:text="${category.spec.description}"
-    >
-    </p>
-  </header>
+  <TaxonomyHeader
+    labelExpr="#{page.categories.title}"
+    label="分类"
+    titleExpr="${category.spec.displayName}"
+    title="Category"
+    descriptionExpr="${category.spec.description}"
+  />
   <PostList />
 </MainGridLayout>

--- a/src/pages/moments.astro
+++ b/src/pages/moments.astro
@@ -107,18 +107,6 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
             </div>
 
             <div
-              th:if="${not #lists.isEmpty(moment.spec.tags)}"
-              class="mt-2 flex flex-wrap gap-x-2 gap-y-1 text-base"
-            >
-              <a
-                th:each="tagName : ${moment.spec.tags}"
-                th:href="@{/moments(tag=${tagName})}"
-                class="link font-medium text-(--primary)"
-                th:text="${'#' + tagName}">#Tag</a
-              >
-            </div>
-
-            <div
               th:if="${content != null and not #lists.isEmpty(content.medium)}"
               th:with="mediaCount=${#lists.size(content.medium)}"
               th:classappend="${' moment-media-count-' + mediaCount}"
@@ -169,6 +157,18 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
                   <span class="truncate" th:text="${momentItem.url}">Post</span>
                 </a>
               </div>
+            </div>
+
+            <div
+              th:if="${not #lists.isEmpty(moment.spec.tags)}"
+              class="mt-4 flex flex-wrap gap-x-2 gap-y-1 text-base"
+            >
+              <a
+                th:each="tagName : ${moment.spec.tags}"
+                th:href="@{/moments(tag=${tagName})}"
+                class="link font-medium text-(--primary)"
+                th:text="${'#' + tagName}">#Tag</a
+              >
             </div>
 
             <div class="mt-4 flex flex-wrap items-center gap-5 text-sm text-50">

--- a/src/pages/tag.astro
+++ b/src/pages/tag.astro
@@ -1,5 +1,6 @@
 ---
 import PostList from "../components/PostList.astro";
+import TaxonomyHeader from "../components/control/TaxonomyHeader.astro";
 import MainGridLayout from "../layouts/MainGridLayout.astro";
 ---
 
@@ -8,16 +9,11 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
   description="#{page.tag.description(${site.title}, ${tag.spec.displayName})}"
 >
   <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
-  <header class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
-    <div class="text-sm font-medium text-50" th:text="#{page.tags.title}">
-      标签
-    </div>
-    <h1
-      class="mt-1 text-3xl font-bold text-90"
-      th:text="${tag.spec.displayName}"
-    >
-      Tag
-    </h1>
-  </header>
+  <TaxonomyHeader
+    labelExpr="#{page.tags.title}"
+    label="标签"
+    titleExpr="${tag.spec.displayName}"
+    title="Tag"
+  />
   <PostList />
 </MainGridLayout>

--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -1,5 +1,6 @@
 ---
 import MainGridLayout from "../layouts/MainGridLayout.astro";
+import PageHeader from "../components/control/PageHeader.astro";
 ---
 
 <MainGridLayout
@@ -8,28 +9,18 @@ import MainGridLayout from "../layouts/MainGridLayout.astro";
 >
   <!-- 页面 <title> 由 Layout.astro 统一输出，此处不再重复定义 -->
   <section class="card-base onload-animation mb-4 px-6 py-6 md:px-9">
-    <div class="min-w-0">
-      <h1
-        class="relative mb-2 text-3xl font-bold text-90 before:absolute before:-left-4.5 before:top-3 before:h-5 before:w-1 before:rounded-md before:bg-(--primary) md:text-4xl"
-        th:text="#{page.tags.title}"
-      >
-        标签
-      </h1>
-      <div class="mb-6 flex flex-wrap items-center gap-1.5 text-sm">
-        <span
-          class="icon-[material-symbols--tag-rounded] text-base text-(--primary)"
-        ></span>
-        <span class="font-bold text-(--primary)" th:text="#{page.tags.subtitle}"
-          >文章标签</span
-        >
-        <span class="text-30">·</span>
-        <span
-          th:if="${tags != null}"
-          th:text="#{page.tags.subtitleCount(${#lists.size(tags)})}"
-          class="text-50">0 个标签</span
-        >
-      </div>
-    </div>
+    <PageHeader
+      containerClass="mb-6"
+      titleExpr="#{page.tags.title}"
+      title="标签"
+      iconClass="icon-[material-symbols--tag-rounded]"
+      labelExpr="#{page.tags.subtitle}"
+      label="文章标签"
+      sepShowIfExpr="${true}"
+      subExpr="#{page.tags.subtitleCount(${#lists.size(tags)})}"
+      sub="0 个标签"
+      subShowIfExpr="${tags != null}"
+    />
     <div class="flex flex-wrap gap-3">
       <a
         th:each="tag, stat : ${tags}"

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1088,6 +1088,11 @@
   font-weight: 600;
 }
 
+/* Moment 插件会把正文中的 #标签渲染为 a.tag；标签列表已在内容末尾统一输出。 */
+.moment-feed-content :where(a.tag) {
+  display: none;
+}
+
 /* 朋友圈时间轴 - 纵向虚线布局
 .friends-timeline {
   display: flex;


### PR DESCRIPTION
针对#48 提出的问题给予修正。
效果图：
<img width="2579" height="1427" alt="image" src="https://github.com/user-attachments/assets/02ee0c1f-bbd1-4146-98f8-489a8e777c6e" />
