### PR TITLE
chore: colord 升级至 2.10.0、js-yaml 统一至 4.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2204,8 +2204,8 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  colord@2.9.3:
-    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+  colord@2.10.0:
+    resolution: {integrity: sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3082,10 +3082,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
-    hasBin: true
 
   js-yaml@4.3.2:
     resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
@@ -6020,7 +6016,7 @@ snapshots:
       archiver: 7.0.1
       commander: 13.1.0
       fs-extra: 11.4.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       path: 0.12.7
     transitivePeerDependencies:
       - bare-abort-controller
@@ -7227,7 +7223,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colord@2.9.3: {}
+  colord@2.10.0: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -8187,10 +8183,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
@@ -8732,7 +8724,7 @@ snapshots:
     dependencies:
       browserslist: 4.28.7
       caniuse-api: 3.0.0
-      colord: 2.9.3
+      colord: 2.10.0
       postcss: 8.5.28
       postcss-value-parser: 4.2.0
 
@@ -8786,7 +8778,7 @@ snapshots:
 
   postcss-minify-gradients@5.1.1(postcss@8.5.28):
     dependencies:
-      colord: 2.9.3
+      colord: 2.10.0
       cssnano-utils: 3.1.0(postcss@8.5.28)
       postcss: 8.5.28
       postcss-value-parser: 4.2.0


### PR DESCRIPTION
刷新两个传递依赖到修复版，清掉 Dependabot 最后两条告警。

- **colord 2.9.3 → 2.10.0**：修复 GHSA-2wm5-q62r-hmrv（超长畸形颜色串导致同步阻塞的 DoS）。来源链为 `@halo-dev/theme-package-cli → microbundle → rollup-plugin-postcss → cssnano@5 → postcss-colormin / postcss-minify-gradients`，两者对 colord 的范围是 `^2.9.1`，容得下 2.10.0。
- **js-yaml 4.3.1 → 4.3.2**：修复 GHSA-2883-xcg3-v3hh（`maxTotalMergeKeys` 不统计空映射，可构造 CPU 耗尽）。`@halo-dev/theme-package-cli` 的范围是 `^4.1.1`，这里直接去重到 astro 侧已引入的 4.3.2，删除冗余条目。

仅 `pnpm-lock.yaml` 改动，无源码变更；已用 `pnpm install --frozen-lockfile --lockfile-only` 校验锁文件自洽。合并后本地跑一次 `pnpm install` 同步 `node_modules` 即可。